### PR TITLE
Deployer user

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ Nullstone Block standing up a static site on S3 in AWS.
 
 ## Inputs
 
-- `owner_id: string` - Stack Owner ID
-- `stack_name: string` - Stack Name
-- `block_name: string` - Block Name
-- `parent_blocks: {}` - Parent Blocks
-- `env: string` - Environment Name
-- `backend_conn_str: string` - Connection string for postgres backend
-
 ## Outputs
 
+- `bucket_arn` - The ARN of the created S3 bucket.
+- `bucket_name` - The name of the created S3 bucket.
+- `origin_domain_name` - The domain name for the created S3 bucket that can be used as an origin for CloudFront.
+- `origin_id` - The ID of the created S3 bucket used as an origin.
+- `origin_access_identity` - A prebuilt CloudFront origin access identity that is configured to work with the created S3 bucket.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Nullstone Block standing up a static site on S3 in AWS.
 - `origin_domain_name` - The domain name for the created S3 bucket that can be used as an origin for CloudFront.
 - `origin_id` - The ID of the created S3 bucket used as an origin.
 - `origin_access_identity` - A prebuilt CloudFront origin access identity that is configured to work with the created S3 bucket.
+- `deployer` - An AWS User with explicit privilege to deploy to the S3 bucket.
+    - `name`       - Deployer username
+    - `access_key` = Access Key ID
+    - `secret_key` = Secret Access Key

--- a/bucket.tf
+++ b/bucket.tf
@@ -14,8 +14,6 @@ resource "aws_s3_bucket" "this" {
   bucket = local.bucket_name
   acl    = "private"
 
-  policy = data.aws_iam_policy_document.s3_policy.json
-
   website {
     index_document = "index.html"
     error_document = "404.html"

--- a/bucket.tf
+++ b/bucket.tf
@@ -31,6 +31,7 @@ resource "aws_s3_bucket_policy" "this" {
 
 data "aws_iam_policy_document" "s3_policy" {
   statement {
+    sid       = "AllowOriginReadObject"
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::${local.bucket_name}/*"]
 
@@ -41,12 +42,31 @@ data "aws_iam_policy_document" "s3_policy" {
   }
 
   statement {
+    sid       = "AllowReadBucket"
     actions   = ["s3:ListBucket"]
     resources = ["arn:aws:s3:::${local.bucket_name}"]
 
     principals {
+      type = "AWS"
+      identifiers = [
+        aws_cloudfront_origin_access_identity.this.iam_arn,
+        aws_iam_user.deployer.arn
+      ]
+    }
+  }
+
+  statement {
+    sid = "AllowDeployerWrite"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject"
+    ]
+    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+
+    principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.this.iam_arn]
+      identifiers = [aws_iam_user.deployer.arn]
     }
   }
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_user" "deployer" {
+  name = "deployer-${random_string.bucket_suffix.result}"
+  tags = data.ns_workspace.this.tags
+}
+
+resource "aws_iam_access_key" "deployer" {
+  user = aws_iam_user.deployer.name
+}
+
+// The actions listed are necessary to perform 'aws s3 sync'
+resource "aws_iam_user_policy" "deployer" {
+  name   = "AllowS3Deploy"
+  user   = aws_iam_user.deployer.name
+  policy = data.aws_iam_policy_document.deployer.json
+}
+
+data "aws_iam_policy_document" "deployer" {
+  statement {
+    sid    = "AllowFindBucket"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+    resources = ["arn:aws:s3:::${local.bucket_name}"]
+  }
+
+  statement {
+    sid    = "AllowEditObjects"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject"
+    ]
+
+    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,15 @@ output "origin_access_identity" {
   value       = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
   description = "string ||| A prebuilt CloudFront origin access identity that is configured to work with the created S3 bucket."
 }
+
+output "deployer" {
+  value = {
+    name       = aws_iam_user.deployer.name
+    access_key = aws_iam_access_key.deployer.id
+    secret_key = aws_iam_access_key.deployer.secret
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to deploy to the S3 bucket."
+
+  sensitive = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "origin_domain_name" {
 
 output "origin_id" {
   value       = "S3-${aws_s3_bucket.this.id}"
-  description = "string ||| The ID of the created S3 bucket."
+  description = "string ||| The ID of the created S3 bucket used as an origin."
 }
 
 output "origin_access_identity" {


### PR DESCRIPTION
This PR adds a `deployer` user who *only* has permission to deploy to the s3 bucket and nothing else.
The README was updated to reflect changes.

Confirmed this is working using nullstone docs site deploying through CircleCI with the deployer user: https://app.circleci.com/pipelines/github/nullstone-io/docs/10/workflows/56a2526c-3824-4f7b-94b1-650c560857b0/jobs/22