### PR TITLE
Converting module to use capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# block-aws-s3-site
+# aws-s3-site
 
-Nullstone Block standing up a static site on S3 in AWS.
+Nullstone App standing up a static site on S3 in AWS.
 
 ## Inputs
 
 ## Outputs
 
+- `region` - The region of the created S3 bucket.
 - `bucket_arn` - The ARN of the created S3 bucket.
 - `bucket_name` - The name of the created S3 bucket.
-- `origin_domain_name` - The domain name for the created S3 bucket that can be used as an origin for CloudFront.
-- `origin_id` - The ID of the created S3 bucket used as an origin.
-- `origin_access_identity` - A prebuilt CloudFront origin access identity that is configured to work with the created S3 bucket.
 - `deployer` - An AWS User with explicit privilege to deploy to the S3 bucket.
     - `name`       - Deployer username
     - `access_key` = Access Key ID
     - `secret_key` = Secret Access Key
+- `private_urls` - A list of URLs accessible from the network
+- `public_urls` - A list of URLs accessible from the internet 

--- a/aws.tf
+++ b/aws.tf
@@ -1,2 +1,1 @@
-provider "aws" {}
 data "aws_region" "this" {}

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "this" {
   bucket = local.resource_name
   acl    = "private"
-  tags   = data.ns_workspace.this.tags
+  tags   = local.tags
 
   website {
     index_document = "index.html"
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "s3_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.this.iam_arn]
+      identifiers = local.oai_iam_arns
     }
   }
 
@@ -33,10 +33,7 @@ data "aws_iam_policy_document" "s3_policy" {
 
     principals {
       type = "AWS"
-      identifiers = [
-        aws_cloudfront_origin_access_identity.this.iam_arn,
-        aws_iam_user.deployer.arn
-      ]
+      identifiers = concat([aws_iam_user.deployer.arn], local.oai_iam_arns)
     }
   }
 

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -1,0 +1,29 @@
+// This file is replaced by code-generation using 'capabilities.tf.tmpl'
+locals {
+  capabilities = {
+    origin_access_identities = [
+      {
+        iam_arn = ""
+      }
+    ]
+
+    // private_urls follows a wonky syntax so that we can send all capability outputs into the merge module
+    // Terraform requires that all members be of type list(map(any))
+    // They will be flattened into list(string) when we output from this module
+    private_urls = [
+      {
+        url = ""
+      }
+    ]
+
+    // public_urls follows a wonky syntax so that we can send all capability outputs into the merge module
+    // Terraform requires that all members be of type list(map(any))
+    // They will be flattened into list(string) when we output from this module
+    public_urls = [
+      {
+        url = ""
+      }
+    ]
+
+  }
+}

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -4,7 +4,7 @@ provider "ns" {
   alias         = "cap_{{ .Id }}"
 }
 
-module "cap_{{ .Id }}" {
+module "{{ .TfModuleName }}" {
   source  = "{{ .Source }}/any"
   {{ if (ne .SourceVersion "latest") }}version = "{{ .SourceVersion }}"{{ end }}
 
@@ -29,6 +29,10 @@ module "caps" {
 }
 
 locals {
-  modules       = [{{ range $index, $element := . }}{{ if $index }}, {{ end }}module.cap_{{ $element.Id }}{{ end }}]
+  modules       = [
+{{- range $index, $element := .ExceptNeedsDestroyed.TfModuleAddrs -}}
+{{ if $index }}, {{ end }}{{ $element }}
+{{- end -}}
+]
   capabilities  = module.caps.outputs
 }

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -1,0 +1,34 @@
+{{ range . -}}
+provider "ns" {
+  capability_id = {{ .Id }}
+  alias         = "cap_{{ .Id }}"
+}
+
+module "cap_{{ .Id }}" {
+  source  = "{{ .Source }}/any"
+  {{ if (ne .SourceVersion "latest") }}version = "{{ .SourceVersion }}"{{ end }}
+
+  app_metadata = {
+    s3_domain_name = aws_s3_bucket.this.bucket_domain_name
+    s3_bucket_id   = aws_s3_bucket.this.id
+  }
+
+  {{- range $key, $value := .Variables }}
+  {{ if not $value.Unused -}}
+  {{ $key }} = jsondecode({{ $value.Value | to_json_string }})
+  {{- end }}{{ end }}
+
+  providers = {
+    ns = ns.cap_{{ .Id}}
+  }
+}
+{{ end }}
+module "caps" {
+  source  = "nullstone-modules/cap-merge/ns"
+  modules = local.modules
+}
+
+locals {
+  modules       = [{{ range $index, $element := . }}{{ if $index }}, {{ end }}module.cap_{{ $element.Id }}{{ end }}]
+  capabilities  = module.caps.outputs
+}

--- a/deployer.tf
+++ b/deployer.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_user" "deployer" {
   name = "deployer-${local.resource_name}"
-  tags = data.ns_workspace.this.tags
+  tags = local.tags
 }
 
 resource "aws_iam_access_key" "deployer" {

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -7,3 +7,7 @@ terraform {
 }
 
 data "ns_workspace" "this" {}
+
+locals {
+  tags = data.ns_workspace.this.tags
+}

--- a/origin.tf
+++ b/origin.tf
@@ -1,3 +1,0 @@
-resource "aws_cloudfront_origin_access_identity" "this" {
-  comment = "${local.resource_name} Managed by Terraform"
-}

--- a/origins.tf
+++ b/origins.tf
@@ -1,0 +1,5 @@
+locals {
+  origin_access_identities = lookup(local.capabilities, "origin_access_identities", [])
+
+  oai_iam_arns = [for oai in local.origin_access_identities : oai.iam_arn]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,21 +12,6 @@ output "bucket_name" {
   description = "string ||| The name of the created S3 bucket."
 }
 
-output "origin_domain_name" {
-  value       = aws_s3_bucket.this.bucket_domain_name
-  description = "string ||| The domain name for the created S3 bucket that can be used as an origin for CloudFront."
-}
-
-output "origin_id" {
-  value       = "S3-${aws_s3_bucket.this.id}"
-  description = "string ||| The ID of the created S3 bucket used as an origin."
-}
-
-output "origin_access_identity" {
-  value       = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
-  description = "string ||| A prebuilt CloudFront origin access identity that is configured to work with the created S3 bucket."
-}
-
 output "deployer" {
   value = {
     name       = aws_iam_user.deployer.name
@@ -37,4 +22,17 @@ output "deployer" {
   description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to deploy to the S3 bucket."
 
   sensitive = true
+}
+
+locals {
+  additional_private_urls = []
+  additional_public_urls = []
+}
+
+output "private_urls" {
+  value = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
+}
+
+output "public_urls" {
+  value = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
 }


### PR DESCRIPTION
This PR adds support for capabilities.
Currently, this only supports the addition of a cloudfront origin.
This also adds outputs for `public_urls` and `private_urls`.