### PR TITLE
C568 spa mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - 'v*'
 
+env:
+  NULLSTONE_ORG: nullstone
+  NULLSTONE_API_KEY: ${{ secrets.NULLSTONE_API_KEY }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -17,20 +21,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Package files into tgz
-      - name: Package
-        run: tar -cvzf module.tgz *.tf *.tf.tmpl README.md
-
       - name: Find version
         id: version
         run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
 
-      # Publish to nullstone
-      - name: Publish
-        env:
-          NULLSTONE_ORG: nullstone
-          NULLSTONE_MODULE: aws-s3-site
-          RELEASE_VERSION: ${{ steps.version.outputs.tag }}
-        run: |-
-          curl -XPOST -F "file=@module.tgz" -H "X-Nullstone-Key: ${{ secrets.NULLSTONE_API_KEY }}" \
-            https://api.nullstone.io/orgs/${NULLSTONE_ORG}/modules/${NULLSTONE_MODULE}/versions?version=${RELEASE_VERSION}
+      - name: Set up Nullstone
+        uses: nullstone-io/setup-nullstone-action@v0
+
+      - name: Publish module
+        run: |
+          nullstone modules publish --version=${{ steps.version.outputs.tag }}

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -18,6 +18,13 @@ locals {
       }
     ]
 
+    env = [
+      {
+        name  = ""
+        value = ""
+      }
+    ]
+
     // private_urls follows a wonky syntax so that we can send all capability outputs into the merge module
     // Terraform requires that all members be of type list(map(any))
     // They will be flattened into list(string) when we output from this module

--- a/env.tf
+++ b/env.tf
@@ -1,0 +1,14 @@
+locals {
+  standard_env_vars = tomap({
+    NULLSTONE_ENV = local.env_name
+  })
+  cap_env_vars = {for kv in try(local.capabilities.env, []) : kv.name => kv.value}
+  env_vars     = merge(local.standard_env_vars, var.service_env_vars, local.cap_env_vars)
+}
+
+resource "aws_s3_bucket_object" "env_file" {
+  bucket       = aws_s3_bucket.this.bucket
+  key          = var.env_vars_filename
+  content      = jsonencode(local.env_vars)
+  content_type = "application/json"
+}

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -20,5 +20,6 @@ resource "random_string" "resource_suffix" {
 locals {
   tags          = data.ns_workspace.this.tags
   block_name    = data.ns_workspace.this.block_name
+  env_name      = data.ns_workspace.this.env_name
   resource_name = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,20 +39,12 @@ output "cdn_ids" {
   value = [for cdn in try(local.capabilities.cdns, []) : cdn["id"]]
 }
 
-locals {
-  // Private and public URLs are shown in the Nullstone UI
-  // Typically, they are created through capabilities attached to the application
-  // If this module has URLs, add them here as list(string) 
-  additional_private_urls = []
-  additional_public_urls  = []
-}
-
 output "private_urls" {
-  value       = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
+  value       = local.private_urls
   description = "list(string) ||| A list of URLs only accessible inside the network"
 }
 
 output "public_urls" {
-  value       = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
+  value       = local.public_urls
   description = "list(string) ||| A list of URLs accessible to the public"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,6 +35,11 @@ output "deployer" {
   sensitive = true
 }
 
+output "env_vars_filename" {
+  value       = var.env_vars_filename
+  description = "string ||| The name of the S3 Object that contains a json-encoded configuration file with environment variables."
+}
+
 output "cdn_ids" {
   value = [for cdn in try(local.capabilities.cdns, []) : cdn["id"]]
 }

--- a/urls.tf
+++ b/urls.tf
@@ -6,6 +6,6 @@ locals {
   additional_public_urls  = []
 
 
-  private_urls = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
-  public_urls  = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
+  private_urls = compact(concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls))
+  public_urls  = compact(concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls))
 }

--- a/urls.tf
+++ b/urls.tf
@@ -1,0 +1,11 @@
+locals {
+  // Private and public URLs are shown in the Nullstone UI
+  // Typically, they are created through capabilities attached to the application
+  // If this module has URLs, add them here as list(string)
+  additional_private_urls = []
+  additional_public_urls  = []
+
+
+  private_urls = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
+  public_urls  = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,19 @@
+variable "service_env_vars" {
+  type        = map(string)
+  default     = {}
+  description = <<EOF
+The environment variables to inject into the service.
+These are typically used to configure a service per environment.
+It is dangerous to put sensitive information in this variable because they are not protected and could be unintentionally exposed.
+EOF
+}
+
+variable "env_vars_filename" {
+  type    = string
+  default = "env.json"
+
+  description = <<EOF
+The name of the configuration file that will store environment variables.
+This should only be changed if the default 'env.json' collides with existing content.
+EOF
+}


### PR DESCRIPTION
This upgrades the module to support environment variables.
These environment variables are emitted to `s3://<artifacts-bucket>/env.json`.

This relies on https://github.com/nullstone-modules/aws-s3-cdn/pull/7 to fully implement.

Updated to use nullstone github action to publish module.