### PR TITLE
F/1209/versioned assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 # aws-s3-site
 
-Nullstone App standing up a static site on S3 in AWS.
+Launch infrastructure for a static site hosted by AWS S3 Bucket.
 
-## Inputs
+## Deploys
 
-## Outputs
+When using the Nullstone CLI or auto-build/deploy functionality, 
+Nullstone pushes the static assets to the S3 Bucket during the "push" phase of deployment.
 
-- `region` - The region of the created S3 bucket.
-- `bucket_arn` - The ARN of the created S3 bucket.
-- `bucket_name` - The name of the created S3 bucket.
-- `deployer` - An AWS User with explicit privilege to deploy to the S3 bucket.
-    - `name`       - Deployer username
-    - `access_key` = Access Key ID
-    - `secret_key` = Secret Access Key
-- `private_urls` - A list of URLs accessible from the network
-- `public_urls` - A list of URLs accessible from the internet 
+If necessary, Nullstone reconfigures a CDN to serve the new assets. 
+Then, Nullstone performs invalidation on the CDN so that the new assets are properly served to users.  
+
+This module supports [Versioned](#versioned-assets) and [Unversioned](#unversioned-assets) Assets.
+By default, Versioned Assets is configured.
+
+### Versioned Assets
+
+When storing assets in the S3 Bucket, Versioned Assets stores each version of assets in a separate subdirectory in the S3 Bucket.
+During deployment, Nullstone reconfigures the CDN to serve assets from the `<version>` S3 subdirectory.
+
+Versioned Assets enables rollback functionality for static site apps and guarantees that assets are not overwritten in the S3 Bucket.
+However, this does not allow serving of assets from multiple deployments.
+
+### Unversioned Assets
+
+When storing assets in the S3 Bucket, Unversioned Assets stores all assets in the root directory of the S3 Bucket.
+
+This disables rollback functionality in Nullstone, but enables serving assets that are uploaded in separate deployments.

--- a/app.tf
+++ b/app.tf
@@ -11,7 +11,8 @@ locals {
 locals {
   app_metadata = tomap({
     // Inject app metadata into capabilities here (e.g. security_group_name, role_name)
-    s3_domain_name = aws_s3_bucket.this.bucket_domain_name
-    s3_bucket_id   = aws_s3_bucket.this.id
+    s3_domain_name         = aws_s3_bucket.this.bucket_domain_name
+    s3_bucket_id           = aws_s3_bucket.this.id
+    artifacts_key_template = local.artifacts_key_template
   })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "artifacts_bucket_name" {
 }
 
 output "artifacts_key_template" {
-  value       = "{{app-version}}/"
+  value       = local.artifacts_key_template
   description = "string ||| Template for s3 directory where files are placed."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,7 @@ variable "enable_versioned_assets" {
   description = "Enable/Disable serving assets from versioned S3 subdirectories"
   default     = true
 }
+
+locals {
+  artifacts_key_template = var.enable_versioned_assets ? "{{app-version}}/" : "/"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,9 @@ The name of the configuration file that will store environment variables.
 This should only be changed if the default 'env.json' collides with existing content.
 EOF
 }
+
+variable "enable_versioned_assets" {
+  type        = bool
+  description = "Enable/Disable serving assets from versioned S3 subdirectories"
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,5 +25,5 @@ variable "enable_versioned_assets" {
 }
 
 locals {
-  artifacts_key_template = var.enable_versioned_assets ? "{{app-version}}/" : "/"
+  artifacts_key_template = var.enable_versioned_assets ? "{{app-version}}/" : ""
 }


### PR DESCRIPTION
This adds a flag to enable "versioned assets" which is enabled by default.
If disabled, the module stores assets in the s3 bucket root instead of `<app-version>/...` to `.

The `artifacts_key_template` (which represents the asset directory) is injected into `app_metadata` for each capability so that a CDN can make decisions based on this value.

I updated the README with basic information and explanation of "versioned assets" functionality.