### PR TITLE
F/logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.0 (Unreleased)
+* Added `var.enable_logging` to save access logs to Cloudwatch.
+* Added support for reading logs in Nullstone.
+
 # 0.11.0 (Sep 22, 2025)
 * Upgrade terraform providers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 0.12.0 (Unreleased)
-* Added `var.enable_logging` to save access logs to Cloudwatch.
+# 0.12.0 (Nov 11, 2025)
 * Added support for reading logs in Nullstone.
+* Added support for displaying metrics in Nullstone.
 * Optimized aggregation of capabilities.
 
 # 0.11.0 (Sep 22, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.12.0 (Unreleased)
 * Added `var.enable_logging` to save access logs to Cloudwatch.
 * Added support for reading logs in Nullstone.
+* Optimized aggregation of capabilities.
 
 # 0.11.0 (Sep 22, 2025)
 * Upgrade terraform providers.

--- a/app.tf
+++ b/app.tf
@@ -17,5 +17,7 @@ locals {
     // https://stackoverflow.com/questions/38735306/aws-cloudfront-redirecting-to-s3-bucket
     // This prevents issues where initial launch forces a redirect to the S3 bucket
     s3_domain_name = aws_s3_bucket.this.bucket_regional_domain_name
+    log_group_name = module.logs.name
+    log_group_arn  = module.logs.arn
   })
 }

--- a/aws.tf
+++ b/aws.tf
@@ -1,1 +1,4 @@
 data "aws_region" "this" {}
+locals {
+  region = data.aws_region.this.region
+}

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -1,27 +1,34 @@
 // This file is replaced by code-generation using 'capabilities.tf.tmpl'
 // This file helps app module creators define a contract for what types of capability outputs are supported.
 locals {
+  cap_modules = [
+    {
+      name       = ""
+      tfId       = ""
+      namespace  = ""
+      env_prefix = ""
+      outputs    = {}
+
+      meta = {
+        subcategory = ""
+        platform    = ""
+        subplatform = ""
+        outputNames = []
+      }
+    }
+  ]
+
+  // cap_env_prefixes is a map indexed by tfId which points to the env_prefix in local.cap_modules
+  cap_env_prefixes = tomap({
+    x = ""
+  })
+
   capabilities = {
-    // origin_access_identities refer to the origin identities that are attached to the cdns
-    // They are granted access to read contents from the S3 Bucket
-    origin_access_identities = [
-      {
-        iam_arn = ""
-      }
-    ]
-
-    // cdns refer to attached Cloudfront Distribution Networks
-    // They are used to serve the static content inside the S3 Bucket
-    cdns = [
-      {
-        id = ""
-      }
-    ]
-
     env = [
       {
-        name  = ""
-        value = ""
+        cap_tf_id = "x"
+        name      = ""
+        value     = ""
       }
     ]
 
@@ -30,7 +37,8 @@ locals {
     // They will be flattened into list(string) when we output from this module
     private_urls = [
       {
-        url = ""
+        cap_tf_id = "x"
+        url       = "http://example"
       }
     ]
 
@@ -39,10 +47,38 @@ locals {
     // They will be flattened into list(string) when we output from this module
     public_urls = [
       {
-        url = ""
+        cap_tf_id = "x"
+        url       = "https://example.com"
+      }
+    ]
+
+    // metrics allows capabilities to attach metrics to the application
+    // These metrics are displayed on the Application Monitoring page
+    // See https://docs.nullstone.io/extending/metrics/overview.html
+    metrics = [
+      {
+        cap_tf_id = "x"
+        name      = ""
+        type      = "usage|usage-percent|duration|generic"
+        unit      = ""
+
+        mappings = jsonencode({})
+      }
+    ]
+
+    cdns = [
+      {
+        cap_tf_id = "x"
+        id        = ""
+        arn       = ""
+      }
+    ]
+
+    origin_access_identities = [
+      {
+        cap_tf_id = "x"
+        iam_arn   = ""
       }
     ]
   }
-
-  cap_env_vars = {}
 }

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -20,19 +20,8 @@ module "{{ .TfModuleName }}" {
   }
 }
 {{ end }}
-module "caps" {
-  source  = "nullstone-modules/cap-merge/ns"
-  modules = local.modules
-}
 
 locals {
-  modules      = [
-{{- range $index, $element := .ExceptNeedsDestroyed.TfModuleAddrs -}}
-{{ if $index }}, {{ end }}{{ $element }}
-{{- end -}}
-]
-  capabilities = module.caps.outputs
-
   cap_modules = [
 {{- range $index, $element := .ExceptNeedsDestroyed }}
     {{ if $index }}, {{ end }}{
@@ -41,15 +30,19 @@ locals {
       namespace  = "{{ $element.Namespace }}"
       env_prefix = "{{ $element.EnvPrefix }}"
       outputs    = {{ $element.TfModuleAddr }}
+
+      meta = jsondecode({{ $element.Meta | to_json_string }})
     }
 {{- end }}
   ]
-}
 
-locals {
-  cap_env_vars = merge([
-    for mod in local.cap_modules : {
-      for item in lookup(mod.outputs, "env", []) : "${mod.env_prefix}${item.name}" => item.value
-    }
-  ]...)
+  cap_env_prefixes = {
+    for mod in local.cap_modules : mod.tfId => mod.env_prefix
+  }
+
+  capabilities = {
+    for outputName in local.capability_output_names : outputName => flatten([
+      for mod in local.cap_modules : [ for x in lookup(mod.outputs, outputName, []) : merge({ cap_tf_id = mod.tfId }, x) ] if contains(try(mod.meta.outputNames, []), outputName)
+    ])
+  }
 }

--- a/capability_outputs.tf
+++ b/capability_outputs.tf
@@ -1,0 +1,12 @@
+locals {
+  // This indicates which outputs are supported by this app module
+  // When adding support for a new output, add it to this list; the output will be available at "local.capabilities.<output_name>"
+  capability_output_names = [
+    "env",
+    "private_urls",
+    "public_urls",
+    "metrics",
+    "cdns",
+    "origin_access_identities",
+  ]
+}

--- a/cdns.tf
+++ b/cdns.tf
@@ -1,4 +1,4 @@
 locals {
-  cdn_ids  = [for cdn in try(local.capabilities.cdns, []) : cdn["id"]]
-  cdn_arns = [for cdn in try(local.capabilities.cdns, []) : cdn["arn"]]
+  cdn_ids  = [for cdn in local.capabilities.cdns : cdn.id]
+  cdn_arns = [for cdn in local.capabilities.cdns : cdn.arn]
 }

--- a/env_vars.tf
+++ b/env_vars.tf
@@ -9,6 +9,10 @@ EOF
 }
 
 locals {
+  cap_env_vars = {
+    for item in local.capabilities.env : "${local.cap_env_prefixes[item.cap_tf_id]}${item.name}" => item.value
+  }
+
   standard_env_vars = tomap({
     NULLSTONE_STACK         = data.ns_workspace.this.stack_name
     NULLSTONE_APP           = data.ns_workspace.this.block_name

--- a/logs.tf
+++ b/logs.tf
@@ -1,0 +1,10 @@
+module "logs" {
+  source  = "nullstone-modules/logs/aws"
+  version = "~> 0.1.0"
+
+  name               = local.resource_name
+  tags               = local.tags
+  enable_log_reader  = true
+  enable_get_metrics = true
+  retention_in_days  = 365
+}

--- a/metrics.tf
+++ b/metrics.tf
@@ -1,0 +1,3 @@
+locals {
+  metrics_mappings = []
+}

--- a/metrics.tf
+++ b/metrics.tf
@@ -1,3 +1,24 @@
 locals {
-  metrics_mappings = []
+  base_metrics = []
+  cap_metrics = [
+    for m in local.capabilities.metrics : {
+      name = m.name
+      type = m.type
+      unit = m.unit
+
+      mappings = {
+        for metric_id, mapping in jsondecode(lookup(m, "mappings", "{}")) : metric_id => {
+          account_id        = mapping.account_id
+          dimensions        = mapping.dimensions
+          stat              = lookup(mapping, "stat", null)
+          namespace         = lookup(mapping, "namespace", null)
+          metric_name       = lookup(mapping, "metric_name", null)
+          expression        = lookup(mapping, "expression", null)
+          hide_from_results = lookup(mapping, "hide_from_results", null)
+        }
+      }
+    }
+  ]
+
+  metrics_mappings = concat(local.base_metrics, local.cap_metrics)
 }

--- a/origins.tf
+++ b/origins.tf
@@ -1,5 +1,3 @@
 locals {
-  origin_access_identities = lookup(local.capabilities, "origin_access_identities", [])
-
-  oai_iam_arns = [for oai in local.origin_access_identities : oai.iam_arn]
+  oai_iam_arns = [for oai in local.capabilities.origin_access_identities : oai.iam_arn]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,7 +41,7 @@ output "env_vars_filename" {
 }
 
 output "cdn_ids" {
-  value = [for cdn in try(local.capabilities.cdns, []) : cdn["id"]]
+  value = local.cdn_ids
 }
 
 output "private_urls" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "region" {
-  value       = data.aws_region.this.region
+  value       = local.region
   description = "string ||| The region where the S3 bucket resides."
 }
 
@@ -52,4 +52,35 @@ output "private_urls" {
 output "public_urls" {
   value       = local.public_urls
   description = "list(string) ||| A list of URLs accessible to the public"
+}
+
+output "log_provider" {
+  value       = "cloudwatch"
+  description = "string ||| 'cloudwatch'"
+}
+
+output "log_group_name" {
+  value       = module.logs.name
+  description = "string ||| The name of the Cloudwatch Log Group where logs are stored."
+}
+
+output "log_reader" {
+  value       = module.logs.reader
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read logs from Cloudwatch."
+  sensitive   = true
+}
+
+output "metrics_provider" {
+  value       = "cloudwatch"
+  description = "string ||| 'cloudwatch'"
+}
+
+output "metrics_reader" {
+  value       = module.logs.reader
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read metrics from Cloudwatch."
+  sensitive   = true
+}
+
+output "metrics_mappings" {
+  value = local.metrics_mappings
 }

--- a/urls.tf
+++ b/urls.tf
@@ -5,8 +5,8 @@ locals {
   additional_private_urls = []
   additional_public_urls  = []
 
-  private_urls = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
-  public_urls  = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
+  private_urls = concat([for cur in local.capabilities.private_urls : cur.url], local.additional_private_urls)
+  public_urls  = concat([for cur in local.capabilities.public_urls : cur.url], local.additional_public_urls)
 }
 
 locals {
@@ -16,7 +16,7 @@ locals {
 locals {
   authority_matcher = "^(?:(?P<user>[^@]*)@)?(?:(?P<host>[^:]*))(?:[:](?P<port>[\\d]*))?"
   // These tests are here to verify the authority_matcher regex above
-  // To verify, uncomment the following lines and issue `echo 'local.tests' | terraform console`
+  // To verify, uncomment the following lines and issue "echo 'local.tests' | terraform console"
   /*
   tests = tomap({
     "nullstone.io" : regex(local.authority_matcher, "nullstone.io"),


### PR DESCRIPTION
This adds a cloudwatch log group (to connect Nullstone logs) and metrics that emits capability metrics for use on the Nullstone Monitoring tab.

Additionally, this upgrades the capabilities template.